### PR TITLE
Add cache busting solution for GitHub Pages

### DIFF
--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -33,7 +33,15 @@ jobs:
         dotnet-version: 8.x
 
     - run: dotnet tool update -g docfx
-    - run: cd docs-docfx && docfx docfx.json
+    - name: Update version timestamp
+      run: |
+        timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+        echo "// This file is automatically updated during the build process" > docs-docfx/version.js
+        echo "window.docsVersion = '1.0.0';" >> docs-docfx/version.js
+        echo "window.lastUpdated = '$timestamp';" >> docs-docfx/version.js
+    
+    - name: Build DocFX
+      run: cd docs-docfx && docfx docfx.json
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3

--- a/docs-docfx/cache-busting-readme.md
+++ b/docs-docfx/cache-busting-readme.md
@@ -1,0 +1,82 @@
+# Cache Busting Solution for GitHub Pages
+
+This document explains the cache busting solution implemented for the XMPro documentation site hosted on GitHub Pages.
+
+## Problem
+
+GitHub Pages serves static content with default cache headers that can cause browsers to cache HTML pages and other resources. This can lead to users not seeing the latest changes unless they perform a hard refresh or open the site in a private/incognito window.
+
+## Solution
+
+The solution implements multiple layers of cache busting to ensure users always get the latest content:
+
+### 1. Cache Control Meta Tags
+
+The HTML pages include the following meta tags to prevent caching:
+
+```html
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
+```
+
+### 2. Service Worker
+
+A service worker (`service-worker.js`) is implemented to control caching behavior:
+
+- HTML files are always fetched from the network first, with cache as a fallback
+- Other resources use a cache-first strategy for better performance
+- The service worker is updated with each build, forcing a refresh of the cache
+- The service worker uses `skipWaiting()` and `clients.claim()` to take control immediately
+
+### 3. Version Tracking
+
+A version tracking system is implemented to detect when new content is available:
+
+- `version.js` contains a timestamp that is updated with each build
+- `version-check.js` periodically checks for a new version and reloads the page if detected
+
+## Implementation Details
+
+### Custom DocFX Template
+
+A custom DocFX template is used to add the cache control meta tags and scripts to the HTML pages.
+
+### GitHub Workflow
+
+The GitHub workflow has been updated to:
+
+1. Generate a new timestamp for each build
+2. Update the `version.js` file with the new timestamp
+3. Build the site with DocFX
+4. Deploy the site to GitHub Pages
+
+### Files Added/Modified
+
+- `templates/modern/partials/head.tmpl.partial` - Added cache control meta tags and scripts
+- `service-worker.js` - Service worker implementation for cache control
+- `register-sw.js` - Script to register the service worker
+- `version.js` - Contains the build timestamp
+- `version-check.js` - Checks for new versions and reloads the page
+- `docfx.json` - Updated to include the new files
+- `.github/workflows/docfx.yml` - Updated to generate a new timestamp with each build
+
+## Testing
+
+To test if the cache busting is working:
+
+1. Visit the site in a normal browser window
+2. Make changes to the site and deploy them
+3. Wait for the deployment to complete
+4. The page should automatically reload with the new content within 5 minutes
+5. Alternatively, you can manually refresh the page to see the changes immediately
+
+## Troubleshooting
+
+If you're still experiencing caching issues:
+
+1. Open the browser's developer tools
+2. Go to the Application tab
+3. Check the Service Worker section to ensure it's active
+4. Check the Cache Storage section to see what's being cached
+5. Try clearing the browser cache manually

--- a/docs-docfx/docfx.json
+++ b/docs-docfx/docfx.json
@@ -14,14 +14,19 @@
     "resource": [
       {
         "files": [
-          "images/**"
+          "images/**",
+          "service-worker.js",
+          "register-sw.js",
+          "version.js",
+          "version-check.js"
         ]
       }
     ],
     "output": "_site",
     "template": [
       "default",
-      "modern"
+      "modern",
+      "templates/modern"
     ],
     "globalMetadata": {
       "_appName": "XMPro",

--- a/docs-docfx/register-sw.js
+++ b/docs-docfx/register-sw.js
@@ -1,0 +1,21 @@
+// Register the service worker
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function() {
+    // Use the lastUpdated timestamp from version.js for cache busting
+    const timestamp = window.lastUpdated ? new Date(window.lastUpdated).getTime() : new Date().getTime();
+    const swUrl = `${window.location.pathname.replace(/\/[^\/]*$/, '')}/service-worker.js?v=${timestamp}`;
+    
+    navigator.serviceWorker.register(swUrl)
+      .then(function(registration) {
+        console.log('ServiceWorker registration successful with scope: ', registration.scope);
+        
+        // Check for updates every hour
+        setInterval(() => {
+          registration.update();
+        }, 3600000); // 1 hour in milliseconds
+      })
+      .catch(function(error) {
+        console.log('ServiceWorker registration failed: ', error);
+      });
+  });
+}

--- a/docs-docfx/service-worker.js
+++ b/docs-docfx/service-worker.js
@@ -1,0 +1,98 @@
+// Service worker for cache control
+const VERSION = new Date().getTime(); // Used for cache busting
+const CACHE_NAME = `xmpro-docs-cache-v1-${VERSION}`;
+
+// Files to cache
+const urlsToCache = [
+  '/',
+  '/index.html'
+];
+
+// Install event - cache basic files and activate immediately
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => {
+        return cache.addAll(urlsToCache);
+      })
+      .then(() => {
+        // Skip waiting to activate the new service worker immediately
+        return self.skipWaiting();
+      })
+  );
+});
+
+// Fetch event - network first, then cache
+self.addEventListener('fetch', event => {
+  // Skip non-GET requests
+  if (event.request.method !== 'GET') return;
+  
+  // Handle HTML files differently - always fetch from network
+  const url = new URL(event.request.url);
+  const isHTMLRequest = event.request.headers.get('accept')?.includes('text/html') 
+    || url.pathname.endsWith('.html') 
+    || url.pathname === '/';
+  
+  if (isHTMLRequest) {
+    // For HTML files, always go to network and update cache
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          // Cache the updated version
+          const clonedResponse = response.clone();
+          caches.open(CACHE_NAME).then(cache => {
+            cache.put(event.request, clonedResponse);
+          });
+          return response;
+        })
+        .catch(() => {
+          // If network fails, try to serve from cache
+          return caches.match(event.request);
+        })
+    );
+  } else {
+    // For other files, try cache first, then network
+    event.respondWith(
+      caches.match(event.request)
+        .then(cachedResponse => {
+          if (cachedResponse) {
+            return cachedResponse;
+          }
+          
+          return fetch(event.request)
+            .then(response => {
+              // Cache the fetched response
+              if (response.status === 200) {
+                const clonedResponse = response.clone();
+                caches.open(CACHE_NAME).then(cache => {
+                  cache.put(event.request, clonedResponse);
+                });
+              }
+              return response;
+            });
+        })
+    );
+  }
+});
+
+// Activate event - clean up old caches and claim clients
+self.addEventListener('activate', event => {
+  const cacheWhitelist = [CACHE_NAME];
+  
+  event.waitUntil(
+    Promise.all([
+      // Clean up old caches
+      caches.keys().then(cacheNames => {
+        return Promise.all(
+          cacheNames.map(cacheName => {
+            if (cacheWhitelist.indexOf(cacheName) === -1) {
+              return caches.delete(cacheName);
+            }
+          })
+        );
+      }),
+      // Take control of all clients
+      self.clients.claim()
+    ])
+  );
+});

--- a/docs-docfx/templates/modern/partials/head.tmpl.partial
+++ b/docs-docfx/templates/modern/partials/head.tmpl.partial
@@ -1,0 +1,57 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
+  
+  <!-- Cache control meta tags -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
+  
+  {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
+  <link rel="icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
+  <link rel="stylesheet" href="{{_rel}}public/docfx.min.css">
+  <link rel="stylesheet" href="{{_rel}}public/main.css">
+  <meta name="docfx:navrel" content="{{_navRel}}">
+  <meta name="docfx:tocrel" content="{{_tocRel}}">
+  {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}
+  {{#_enableSearch}}<meta name="docfx:rel" content="{{_rel}}">{{/_enableSearch}}
+  {{#_enableNewTab}}<meta name="docfx:newtab" content="true">{{/_enableNewTab}}
+  {{#_disableNewTab}}<meta name="docfx:disablenewtab" content="true">{{/_disableNewTab}}
+  {{#_disableTocFilter}}<meta name="docfx:disabletocfilter" content="true">{{/_disableTocFilter}}
+  {{#docurl}}<meta name="docfx:docurl" content="{{docurl}}">{{/docurl}}
+  <meta name="loc:inThisArticle" content="{{__global.inThisArticle}}">
+  <meta name="loc:searchResultsCount" content="{{__global.searchResultsCount}}">
+  <meta name="loc:searchNoResults" content="{{__global.searchNoResults}}">
+  <meta name="loc:tocFilter" content="{{__global.tocFilter}}">
+  <meta name="loc:nextArticle" content="{{__global.nextArticle}}">
+  <meta name="loc:prevArticle" content="{{__global.prevArticle}}">
+  <meta name="loc:themeLight" content="{{__global.themeLight}}">
+  <meta name="loc:themeDark" content="{{__global.themeDark}}">
+  <meta name="loc:themeAuto" content="{{__global.themeAuto}}">
+  <meta name="loc:changeTheme" content="{{__global.changeTheme}}">
+  <meta name="loc:copy" content="{{__global.copy}}">
+  <meta name="loc:downloadPdf" content="{{__global.downloadPdf}}">
+
+  <script type="module" src="./{{_rel}}public/docfx.min.js"></script>
+  <script src="{{_rel}}version.js"></script>
+  <script src="{{_rel}}register-sw.js"></script>
+  <script src="{{_rel}}version-check.js"></script>
+
+  <script>
+    const theme = localStorage.getItem('theme') || 'auto'
+    document.documentElement.setAttribute('data-bs-theme', theme === 'auto' ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : theme)
+  </script>
+
+  {{#_googleAnalyticsTagId}}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{_googleAnalyticsTagId}}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', '{{_googleAnalyticsTagId}}');
+  </script>
+  {{/_googleAnalyticsTagId}}
+</head>

--- a/docs-docfx/version-check.js
+++ b/docs-docfx/version-check.js
@@ -1,0 +1,36 @@
+// Version check script to force reload when a new version is detected
+(function() {
+  // Check for new version every 5 minutes
+  const CHECK_INTERVAL = 5 * 60 * 1000; // 5 minutes in milliseconds
+  
+  // Store the current version
+  const currentVersion = window.lastUpdated;
+  
+  // Function to check for new version
+  function checkForNewVersion() {
+    // Fetch the version.js file with a cache-busting parameter
+    fetch('version.js?' + new Date().getTime())
+      .then(response => response.text())
+      .then(text => {
+        // Extract the lastUpdated value from the fetched file
+        const match = text.match(/window\.lastUpdated\s*=\s*['"]([^'"]+)['"]/);
+        if (match && match[1]) {
+          const fetchedVersion = match[1];
+          
+          // If the version has changed, reload the page
+          if (fetchedVersion !== currentVersion) {
+            console.log('New version detected. Reloading page...');
+            window.location.reload(true); // Force reload from server
+          }
+        }
+      })
+      .catch(error => {
+        console.error('Error checking for new version:', error);
+      });
+  }
+  
+  // Start checking for new version after the page has loaded
+  if (currentVersion) {
+    setInterval(checkForNewVersion, CHECK_INTERVAL);
+  }
+})();

--- a/docs-docfx/version.js
+++ b/docs-docfx/version.js
@@ -1,0 +1,3 @@
+// This file is automatically updated during the build process
+window.docsVersion = '1.0.0';
+window.lastUpdated = new Date().toISOString();


### PR DESCRIPTION
This commit implements a comprehensive cache busting solution for the GitHub Pages site to ensure users always see the latest content without having to use private/incognito windows.

The solution includes:
- Cache control meta tags in HTML pages
- Service worker for controlling cache behavior
- Version tracking system to detect new content
- Updated GitHub workflow to generate timestamps with each build